### PR TITLE
Added error message on error on compilation

### DIFF
--- a/compile.js
+++ b/compile.js
@@ -20,6 +20,11 @@ async function execute() {
     const source = await readFile(contractPath, 'utf8')
     const output = solc.compile(source, 1)
 
+    if(output.errors){
+        output.errors.map((e) => { console.log(e); });
+        return
+    }
+
     const str = JSON.stringify(output.contracts[':LandRegistry'])
     await writeFile(outputPath, str, 'utf8')
 }


### PR DESCRIPTION
If the compilation process failed, the compiled JSON only had an `undefined` string and it failed silently. I added an error checker, and if there were any errors with solc, it logs the error and doesn't update the JSON file.